### PR TITLE
feat: grid map and modern ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # TD-test-01
-TD 2D
+
+Prototype for a 2D PvP tower defense game.
+
+## Development
+
+Requires Node.js. Install dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+Then open `http://localhost:3000` in two browsers on the same LAN.
+
+Client files are served from `/client` via Express and socket.io.
+
+## Gameplay
+
+1. Run the server and open the page on two computers in the same LAN.
+2. One player chooses **Host** and shares the displayed IP. The other clicks **Conectarse**.
+3. When both are connected, the Host can start the match.
+4. Each player gains money over time to build turrets, walls or send waves of soldiers.

--- a/client/game/entities.js
+++ b/client/game/entities.js
@@ -1,0 +1,72 @@
+export class Soldier {
+  constructor(owner, path, color, direction) {
+    this.owner = owner;
+    this.path = path;
+    this.color = color;
+    this.t = direction === 'up' ? 1 : 0; // 0 start at top? Wait host bottom: host direction up, client direction down
+    this.direction = direction; // 'up' or 'down'
+    this.speed = 40; // pixels per second
+    this.hp = 5;
+    this.alive = true;
+  }
+  update(dt) {
+    const step = this.speed * dt / totalPathLength(this.path);
+    this.t += this.direction === 'up' ? -step : step;
+    this.t = Math.max(0, Math.min(1, this.t));
+    const pos = pointAt(this.path, this.t);
+    this.x = pos.x; this.y = pos.y;
+  }
+}
+
+export class Turret {
+  constructor(owner, x, y, color) {
+    this.owner = owner;
+    this.x = x; this.y = y;
+    this.color = color;
+    this.range = 60;
+    this.cooldown = 0;
+  }
+  update(dt, soldiers) {
+    if (this.cooldown > 0) this.cooldown -= dt;
+    else {
+      const target = soldiers.find(s => s.owner !== this.owner && s.alive && dist(s, this) < this.range);
+      if (target) {
+        target.hp -= 5;
+        if (target.hp <= 0) target.alive = false;
+        this.cooldown = 0.5; // fire every 0.5s
+      }
+    }
+  }
+}
+
+export class Wall {
+  constructor(owner, x, y, color) {
+    this.owner = owner;
+    this.x = x; this.y = y;
+    this.color = color;
+    this.hp = 6;
+  }
+}
+
+export function pointAt(path, t) {
+  const total = path.length - 1;
+  const idx = Math.min(Math.floor(t * total), total - 1);
+  const localT = t * total - idx;
+  const a = path[idx];
+  const b = path[idx + 1];
+  return { x: a.x + (b.x - a.x) * localT, y: a.y + (b.y - a.y) * localT };
+}
+
+export function totalPathLength(path) {
+  let len = 0;
+  for (let i = 0; i < path.length - 1; i++) {
+    const a = path[i];
+    const b = path[i + 1];
+    len += Math.hypot(b.x - a.x, b.y - a.y);
+  }
+  return len;
+}
+
+export function dist(a, b) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}

--- a/client/game/game.js
+++ b/client/game/game.js
@@ -1,0 +1,180 @@
+import { generatePath, distanceToPath } from './path.js';
+import { Soldier, Turret, Wall, pointAt, dist } from './entities.js';
+
+export class Game {
+  constructor(canvas, role, color, hostColor, clientColor) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.role = role;
+    this.color = color;
+    this.hostColor = hostColor;
+    this.clientColor = clientColor;
+    this.enemyColor = role === 'host' ? clientColor : hostColor;
+    this.money = 20;
+    this.baseHp = 100;
+    this.lastTime = 0;
+    this.mode = null; // 'turret' | 'wall'
+    this.path = [];
+    this.soldiers = [];
+    this.turrets = [];
+    this.walls = [];
+    this.cellSize = 40;
+  }
+
+  generate(seed) {
+    this.path = generatePath(seed, this.canvas.width, this.canvas.height, this.cellSize);
+  }
+
+  update(time) {
+    const dt = (time - this.lastTime) / 1000;
+    this.lastTime = time;
+    this.money += dt; // +1 per second
+    this.soldiers.forEach(s => s.alive && s.update(dt));
+    this.soldiers = this.soldiers.filter(s => s.alive);
+    this.turrets.forEach(t => t.update(dt, this.soldiers));
+    // soldiers vs walls
+    this.soldiers.forEach(s => {
+      const target = this.walls.find(w => w.owner !== s.owner && dist(w, s) < this.cellSize / 2);
+      if (target) {
+        target.hp -= 2 * dt;
+        if (target.hp <= 0) this.walls.splice(this.walls.indexOf(target), 1);
+        s.speed = 0;
+      } else {
+        s.speed = 40;
+      }
+    });
+    // soldiers reaching base
+    this.soldiers.forEach(s => {
+      if ((s.direction === 'up' && s.t <= 0) || (s.direction === 'down' && s.t >= 1)) {
+        this.baseHp -= 1;
+        s.alive = false;
+      }
+    });
+  }
+
+  render() {
+    const ctx = this.ctx;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    // zones
+    ctx.fillStyle = hexToRgba(this.hostColor, 0.1);
+    ctx.fillRect(0, 0, this.canvas.width / 2, this.canvas.height);
+    ctx.fillStyle = hexToRgba(this.clientColor, 0.1);
+    ctx.fillRect(this.canvas.width / 2, 0, this.canvas.width / 2, this.canvas.height);
+
+    // grid
+    ctx.strokeStyle = '#222';
+    ctx.lineWidth = 1;
+    for (let x = 0; x <= this.canvas.width; x += this.cellSize) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, this.canvas.height);
+      ctx.stroke();
+    }
+    for (let y = 0; y <= this.canvas.height; y += this.cellSize) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(this.canvas.width, y);
+      ctx.stroke();
+    }
+
+    // path
+    ctx.strokeStyle = '#444';
+    ctx.lineWidth = this.cellSize / 2;
+    ctx.lineCap = 'square';
+    ctx.beginPath();
+    this.path.forEach((p, i) => {
+      if (i === 0) ctx.moveTo(p.x, p.y);
+      else ctx.lineTo(p.x, p.y);
+    });
+    ctx.stroke();
+
+    // base towers
+    ctx.fillStyle = this.hostColor;
+    ctx.fillRect(0, this.canvas.height - this.cellSize, this.cellSize, this.cellSize);
+    ctx.fillStyle = this.clientColor;
+    ctx.fillRect(this.canvas.width - this.cellSize, 0, this.cellSize, this.cellSize);
+
+    // walls
+    this.walls.forEach(w => {
+      ctx.fillStyle = w.color;
+      ctx.fillRect(w.x - this.cellSize / 2, w.y - this.cellSize / 2, this.cellSize, this.cellSize);
+    });
+
+    // turrets
+    this.turrets.forEach(t => {
+      ctx.fillStyle = t.color;
+      ctx.beginPath();
+      ctx.arc(t.x, t.y, this.cellSize / 2 - 2, 0, Math.PI * 2);
+      ctx.fill();
+    });
+
+    // soldiers
+    this.soldiers.forEach(s => {
+      ctx.fillStyle = s.color;
+      ctx.fillRect(s.x - this.cellSize / 4, s.y - this.cellSize / 4, this.cellSize / 2, this.cellSize / 2);
+    });
+  }
+
+  gameLoop = (time) => {
+    this.update(time);
+    this.render();
+    requestAnimationFrame(this.gameLoop);
+  }
+
+  start(seed) {
+    this.generate(seed);
+    this.lastTime = performance.now();
+    requestAnimationFrame(this.gameLoop);
+  }
+
+  tryPlace(x, y, owner = this.role, color = this.color, type = this.mode) {
+    const gx = Math.floor(x / this.cellSize) * this.cellSize + this.cellSize / 2;
+    const gy = Math.floor(y / this.cellSize) * this.cellSize + this.cellSize / 2;
+    const half = this.canvas.width / 2;
+    if (owner === 'host' && gx >= half) return;
+    if (owner === 'client' && gx < half) return;
+    const point = { x: gx, y: gy };
+    const d = distanceToPath(point, this.path);
+    if (type === 'turret') {
+      if (d > this.cellSize / 2) {
+        if (owner === this.role) {
+          if (this.money < 15) return;
+          this.money -= 15;
+        }
+        this.turrets.push(new Turret(owner, gx, gy, color));
+      }
+    } else if (type === 'wall') {
+      const onPath = this.path.some(p => p.x === gx && p.y === gy);
+      if (onPath) {
+        if (owner === this.role) {
+          if (this.money < 10) return;
+          this.money -= 10;
+        }
+        this.walls.push(new Wall(owner, gx, gy, color));
+      }
+    }
+  }
+
+  spawnWave(owner = this.role, color = this.color) {
+    if (owner === this.role) {
+      if (this.money < 20) return;
+      this.money -= 20;
+    }
+    const dir = owner === 'host' ? 'up' : 'down';
+    for (let i = 0; i < 3; i++) {
+      const s = new Soldier(owner, this.path, color, dir);
+      s.t += (i * 0.02) * (dir === 'up' ? -1 : 1);
+      this.soldiers.push(s);
+    }
+  }
+}
+
+function hexToRgba(hex, alpha) {
+  const h = hex.replace('#', '');
+  const bigint = parseInt(h, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r},${g},${b},${alpha})`;
+}

--- a/client/game/path.js
+++ b/client/game/path.js
@@ -1,0 +1,57 @@
+// Generate deterministic path on a grid using seeded random
+export function generatePath(seed, width, height, cell = 40) {
+  const rand = mulberry32(hashCode(seed));
+  const cols = Math.floor(width / cell);
+  const rows = Math.floor(height / cell);
+  let x = cols - 1; // start at top-right for client base
+  let y = 0;
+  const points = [{ x: x * cell + cell / 2, y: y * cell + cell / 2 }];
+  while (x > 0 || y < rows - 1) {
+    const moves = [];
+    if (x > 0) moves.push('left');
+    if (y < rows - 1) moves.push('down');
+    const move = moves[Math.floor(rand() * moves.length)];
+    if (move === 'left') x--;
+    else y++;
+    points.push({ x: x * cell + cell / 2, y: y * cell + cell / 2 });
+  }
+  return points;
+}
+
+function hashCode(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+  }
+  return h;
+}
+
+function mulberry32(a) {
+  return function () {
+    a |= 0; a = a + 0x6D2B79F5 | 0;
+    let t = Math.imul(a ^ a >>> 15, 1 | a);
+    t ^= t + Math.imul(t ^ t >>> 7, 61 | t);
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  }
+}
+
+// helper to compute closest point on path for placement validation
+export function distanceToPath(point, path) {
+  let min = Infinity;
+  for (let i = 0; i < path.length - 1; i++) {
+    const a = path[i];
+    const b = path[i + 1];
+    const d = distToSegment(point, a, b);
+    if (d < min) min = d;
+  }
+  return min;
+}
+
+function distToSegment(p, a, b) {
+  const l2 = (b.x - a.x) ** 2 + (b.y - a.y) ** 2;
+  if (l2 === 0) return Math.hypot(p.x - a.x, p.y - a.y);
+  let t = ((p.x - a.x) * (b.x - a.x) + (p.y - a.y) * (b.y - a.y)) / l2;
+  t = Math.max(0, Math.min(1, t));
+  const proj = { x: a.x + t * (b.x - a.x), y: a.y + t * (b.y - a.y) };
+  return Math.hypot(p.x - proj.x, p.y - proj.y);
+}

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>TD PvP</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="menu" class="panel">
+    <h1>TD PvP</h1>
+    <label>Nombre<br/><input id="name" type="text" /></label>
+    <label>Color<br/><input id="color" type="color" value="#0000ff" /></label>
+    <div class="buttons">
+      <button id="hostBtn" class="action">Host</button>
+      <button id="joinBtn" class="action">Conectarse</button>
+    </div>
+    <div id="ipDisplay"></div>
+  </div>
+  <div id="hud" class="hidden">
+    <div id="statsPanel" class="panel">
+      <div id="money">💰20</div>
+      <div id="baseHp">❤️100</div>
+      <div id="actions" class="buttons">
+        <button id="buildTurret" class="action">Torreta</button>
+        <button id="buildWall" class="action">Muro</button>
+        <button id="sendWave" class="action">Enviar oleada</button>
+      </div>
+    </div>
+  </div>
+  <canvas id="game"></canvas>
+  <script src="/socket.io/socket.io.js"></script>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/client/main.js
+++ b/client/main.js
@@ -1,0 +1,133 @@
+import { Game } from './game/game.js';
+
+const socket = io();
+
+const nameInput = document.getElementById('name');
+const colorInput = document.getElementById('color');
+const hostBtn = document.getElementById('hostBtn');
+const joinBtn = document.getElementById('joinBtn');
+const menu = document.getElementById('menu');
+const hud = document.getElementById('hud');
+const ipDisplay = document.getElementById('ipDisplay');
+const moneySpan = document.getElementById('money');
+const baseHpSpan = document.getElementById('baseHp');
+const buildTurretBtn = document.getElementById('buildTurret');
+const buildWallBtn = document.getElementById('buildWall');
+const sendWaveBtn = document.getElementById('sendWave');
+const canvas = document.getElementById('game');
+const startBtn = document.createElement('button');
+startBtn.textContent = 'Iniciar partida';
+startBtn.id = 'startGame';
+
+let role = null;
+let game = null;
+
+hostBtn.addEventListener('click', () => {
+  role = 'host';
+  socket.emit('register', {
+    role: 'host',
+    name: nameInput.value || 'Host',
+    color: colorInput.value,
+  });
+});
+
+joinBtn.addEventListener('click', () => {
+  role = 'client';
+  socket.emit('register', {
+    role: 'client',
+    name: nameInput.value || 'Cliente',
+    color: colorInput.value,
+  });
+});
+
+socket.on('ip', (ip) => {
+  ipDisplay.textContent = `IP Host: ${ip}`;
+});
+
+socket.on('errorMsg', (msg) => {
+  alert(msg);
+});
+
+socket.on('lobbyState', ({ hostConnected, clientConnected }) => {
+  if (hostConnected && clientConnected) {
+    if (role === 'host' && !document.getElementById('startGame')) {
+      menu.appendChild(startBtn);
+      startBtn.disabled = false;
+      startBtn.addEventListener('click', () => {
+        socket.emit('startGame');
+        startBtn.disabled = true;
+      });
+    }
+  }
+});
+
+socket.on('startGame', ({ seed, hostColor, clientColor }) => {
+  menu.classList.add('hidden');
+  hud.classList.remove('hidden');
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  game = new Game(canvas, role, colorInput.value, hostColor, clientColor);
+  game.start(seed);
+  requestAnimationFrame(updateHud);
+});
+
+function updateHud() {
+  if (!game) return;
+  moneySpan.textContent = `💰${Math.floor(game.money)}`;
+  baseHpSpan.textContent = `❤️${Math.floor(game.baseHp)}`;
+  toggleAffordable(buildTurretBtn, game.money >= 15);
+  toggleAffordable(buildWallBtn, game.money >= 10);
+  toggleAffordable(sendWaveBtn, game.money >= 20);
+  requestAnimationFrame(updateHud);
+}
+
+function toggleAffordable(btn, ok) {
+  btn.classList.toggle('affordable', ok);
+  btn.classList.toggle('unaffordable', !ok);
+}
+
+buildTurretBtn.addEventListener('click', () => {
+  if (game) game.mode = 'turret';
+});
+buildWallBtn.addEventListener('click', () => {
+  if (game) game.mode = 'wall';
+});
+
+canvas.addEventListener('click', (e) => {
+  if (!game || !game.mode) return;
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  game.tryPlace(x, y);
+  if (game.mode === 'turret') {
+    socket.emit('placeTurret', { x, y });
+  } else if (game.mode === 'wall') {
+    socket.emit('placeWall', { x, y });
+  }
+  game.mode = null;
+});
+
+sendWaveBtn.addEventListener('click', () => {
+  if (game) {
+    socket.emit('spawnWave');
+  }
+});
+
+socket.on('spawnWave', ({ owner, color }) => {
+  if (!game) return;
+  game.spawnWave(owner, color);
+});
+
+socket.on('placeTurret', ({ owner, x, y, color }) => {
+  if (!game) return;
+  if (owner !== role) {
+    game.tryPlace(x, y, owner, color, 'turret');
+  }
+});
+
+socket.on('placeWall', ({ owner, x, y, color }) => {
+  if (!game) return;
+  if (owner !== role) {
+    game.tryPlace(x, y, owner, color, 'wall');
+  }
+});

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,0 +1,72 @@
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #0e1116;
+  color: #ddd;
+}
+
+.hidden {
+  display: none;
+}
+
+.panel {
+  background: rgba(31, 41, 53, 0.8);
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+#menu {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  width: 300px;
+}
+
+#hud {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+#statsPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 120px;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+button.action {
+  border-radius: 8px;
+  border: 2px solid #444;
+  background: linear-gradient(#1f2935, #151a20);
+  color: #ddd;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+button.action.affordable {
+  border-color: #2ecc71;
+  box-shadow: 0 0 8px rgba(46, 204, 113, 0.6);
+}
+
+button.action.unaffordable {
+  border-color: #e74c3c;
+  box-shadow: 0 0 8px rgba(231, 76, 60, 0.6);
+}
+
+canvas {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "td-test-01",
+  "version": "1.0.0",
+  "description": "TD 2D",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\"",
+    "server": "node ./server/index.js",
+    "start": "npm run server"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.5"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,87 @@
+import express from 'express';
+import http from 'http';
+import { Server } from 'socket.io';
+import os from 'os';
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+
+const PORT = process.env.PORT || 3000;
+
+// serve static files from client directory
+app.use(express.static('client'));
+
+let hostId = null;
+let clientId = null;
+const players = {}; // socket.id -> {role,name,color}
+
+io.on('connection', (socket) => {
+  socket.on('register', ({ role, name, color }) => {
+    if (role === 'host') {
+      if (hostId) {
+        socket.emit('errorMsg', 'Host already exists');
+        return;
+      }
+      hostId = socket.id;
+      socket.emit('ip', getLocalIp());
+    } else if (role === 'client') {
+      if (clientId) {
+        socket.emit('errorMsg', 'Client already connected');
+        return;
+      }
+      clientId = socket.id;
+    }
+    players[socket.id] = { role, name, color };
+    io.emit('lobbyState', { hostConnected: !!hostId, clientConnected: !!clientId });
+  });
+
+  socket.on('startGame', () => {
+    if (socket.id !== hostId) return; // only host can start
+    const seed = Date.now().toString();
+    const hostColor = players[hostId]?.color || '#0000ff';
+    const clientColor = players[clientId]?.color || '#ff0000';
+    io.emit('startGame', { seed, hostColor, clientColor });
+  });
+
+  socket.on('spawnWave', () => {
+    const player = players[socket.id];
+    if (!player) return;
+    io.emit('spawnWave', { owner: player.role, color: player.color });
+  });
+
+  socket.on('placeTurret', ({ x, y }) => {
+    const player = players[socket.id];
+    if (!player) return;
+    io.emit('placeTurret', { owner: player.role, x, y, color: player.color });
+  });
+
+  socket.on('placeWall', ({ x, y }) => {
+    const player = players[socket.id];
+    if (!player) return;
+    io.emit('placeWall', { owner: player.role, x, y, color: player.color });
+  });
+
+  socket.on('disconnect', () => {
+    if (socket.id === hostId) hostId = null;
+    if (socket.id === clientId) clientId = null;
+    delete players[socket.id];
+    io.emit('lobbyState', { hostConnected: !!hostId, clientConnected: !!clientId });
+  });
+});
+
+function getLocalIp() {
+  const interfaces = os.networkInterfaces();
+  for (const name of Object.keys(interfaces)) {
+    for (const iface of interfaces[name]) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        return iface.address;
+      }
+    }
+  }
+  return '0.0.0.0';
+}
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- modernize menu and in-game HUD with rounded translucent panels and affordability highlights
- generate grid-based path, tint each player zone, and draw base towers on opposite corners
- broadcast player colors on start and restrict building to each player's half of the map

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm start` *(fails: Cannot find package 'express' imported from server/index.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aca46b77808322894ff19ecc352c5c